### PR TITLE
Allow && tenary operators.

### DIFF
--- a/rules/best-practices.json
+++ b/rules/best-practices.json
@@ -52,7 +52,7 @@
     "no-sequences": "error",
     "no-throw-literal": "error",
     "no-unmodified-loop-condition": "error",
-    "no-unused-expressions": "error",
+    "no-unused-expressions": ["error", { "allowShortCircuit": true }],
     "no-unused-labels": "error",
     "no-useless-call": "error",
     "no-useless-concat": "error",

--- a/rules/stylistic-issues.json
+++ b/rules/stylistic-issues.json
@@ -60,7 +60,7 @@
     "one-var-declaration-per-line": ["error", "always"],
     "one-var": ["error", "never"],
     "operator-assignment": ["error", "always"],
-    "operator-linebreak": ["error", "none", { "overrides": { "?": "ignore", ":": "ignore" } }],
+    "operator-linebreak": ["error", "none", { "overrides": { "&&": "ignore", "?": "ignore", ":": "ignore" } }],
     "padded-blocks": ["error", "never"],
     "quote-props": ["error", "consistent-as-needed"],
     "quotes": ["error", "single", { "allowTemplateLiterals": true }],


### PR DESCRIPTION
Appenending options for code in the style of:

```
{condition && 
  <Component />
}
```